### PR TITLE
docs: update README.md to suggest forking due to GitHub's wide permission scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           github_token: ${{ secrets.GH_PAT }}
 ```
 
-Note that the default `secrets.GITHUB_TOKEN` hasn't got [enough permissions][token-permissions], and cannot update the repository's topics. You should create a repo scoped [personal access token][pat] instead. Alternativly, you can fork the repo and replace the action name to use your fork after reviewing the code to ensure security of your repository. This would mitigate the non-granular GitHub PAT permission scopes.
+Note that the default `secrets.GITHUB_TOKEN` hasn't got [enough permissions][token-permissions], and cannot update the repository's topics. You should create a repo scoped [personal access token][pat] instead. Alternatively, you can fork the repo and replace the action name to use your fork after reviewing the code to ensure security of your repository. This would mitigate the non-granular GitHub PAT permission scopes.
 
 [token-permissions]: https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
 [pat]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           github_token: ${{ secrets.GH_PAT }}
 ```
 
-Note that the default `secrets.GITHUB_TOKEN` hasn't got [enough permissions][token-permissions], and cannot update the repository's topics. You should create a repo scoped [personal access token][pat] instead.
+Note that the default `secrets.GITHUB_TOKEN` hasn't got [enough permissions][token-permissions], and cannot update the repository's topics. You should create a repo scoped [personal access token][pat] instead. Alternativly, you can fork the repo and replace the action name to use your fork after reviewing the code to ensure security of your repository. This would mitigate the non-granular GitHub PAT permission scopes.
 
 [token-permissions]: https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
 [pat]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token


### PR DESCRIPTION
Thanks @browniebroke, action is awesome and i've deployed it to  my repos:  in https://github.com/web-scheduler/